### PR TITLE
Migrate metadata and package dependencies to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pymangaj"
+version = "0.1.7"
+description = "Search and download mangas."
+authors = [
+    {name = "Jean Jacques Barros", email = "jjean.jacques10@gmail.com"},
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+    'Development Status :: 3 - Alpha',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+]
+requires-python = ">=3.6"
+dependencies = [
+    "requests == 2.28.1",
+    "beautifulsoup4 == 4.12.2",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest"
+]
+
+[project.urls]
+homepage = "https://pypi.org/project/pymangaj/"
+documentation = "https://github.com/jjeanjacques10/pymangaj"
+repository = "https://github.com/jjeanjacques10/pymangaj"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-requests==2.28.1
-beautifulsoup4==4.12.2
-pytest
-unittest

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-with open("README.md", "r", encoding="utf-8") as f:
-    long_description = f.read()
-
-setup(
-    name='pymangaj',
-    version='0.1.7',
-    description='Search and download mangas.',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author='Jean Jacques Barros',
-    author_email='jjean.jacques10@gmail.com',
-    url='https://github.com/jjeanjacques10/pymangaj',
-    packages=find_packages(),
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-)
+setup()


### PR DESCRIPTION
migrated the metadata from setup.py to `pyproject.toml`, but not excluding the setup.py for compatibility purposes. Also migrated the package dependencies and sorted the core dependencies from test dependencies.

resolve: #3